### PR TITLE
Added Plugins css\js support

### DIFF
--- a/Config/routes.php
+++ b/Config/routes.php
@@ -7,5 +7,5 @@
  * It will call the appropriate url depending on what assets we're calling in our YUI Loader.
  * If we only had one URL, YUI would try to concatenate JS and CSS files into one HTTP request which would break everything
  */
-	Router::connect('/min-js', array('plugin' => 'Minify', 'controller' => 'minify', 'action' => 'index'));
-	Router::connect('/min-css', array('plugin' => 'Minify', 'controller' => 'minify', 'action' => 'index'));
+	Router::connect('/min-js', array('plugin' => 'Minify', 'controller' => 'minify', 'action' => 'index', 'js'));
+	Router::connect('/min-css', array('plugin' => 'Minify', 'controller' => 'minify', 'action' => 'index', 'css'));

--- a/Controller/MinifyController.php
+++ b/Controller/MinifyController.php
@@ -16,8 +16,40 @@ class MinifyController extends Controller {
 	 *
 	 * @return void
 	 */
-	public function index() {
-		App::import('Minify.Vendor', 'minify' . DS . 'index');
+	public function index($type) {
+		$files = array_unique(explode(',', $_GET['f']));
+		$plugins = array();
+		$pluginSymlinks = array();
+		$newFiles = array();
+		foreach ($files as &$file)
+		{
+		    if (empty($file))
+		    {
+			continue;
+		    }
+		    
+		    $plugin = false;
+		    list($first, $second) = pluginSplit($file);
+		    if (CakePlugin::loaded($first) === true) {
+			$file = $second;
+			$plugin = $first;
+		    }
+
+		    $pluginPath = (!empty($plugin) ? '..' . DS . 'Plugin' . DS . $plugin . DS . WEBROOT_DIR . DS : '');
+		    $file = $pluginPath . $type . DS . $file . '.' . $type;
+		    $newFiles[] = $file;
+
+		    if (!empty($plugin) && !isset($plugins[$plugin]))
+		    {
+			$plugins[$plugin] = true;
+
+			$pluginSymlinks['/' . $this->request->base . '/' . Inflector::underscore($plugin)] = APP . 'Plugin' . DS . $plugin . DS . WEBROOT_DIR;
+		    }
+		}
+		$_GET['f'] = implode(',', $newFiles);
+		$_GET['symlinks'] = $pluginSymlinks;
+
+		App::import('Vendor', 'Minify.minify/index');
 
 		$this->response->statusCode('304');
 		exit;

--- a/Vendor/minify/config.php
+++ b/Vendor/minify/config.php
@@ -121,7 +121,7 @@ $min_serveOptions['maxAge'] = 1800;
  *
  * // = shortcut for DOCUMENT_ROOT
  */
-//$min_serveOptions['minApp']['allowDirs'] = array('//js', '//css');
+$min_serveOptions['minApp']['allowDirs'] = array('//js', '//css');
 
 /**
  * Set to true to disable the "f" GET parameter for specifying files.
@@ -152,7 +152,7 @@ $min_serveOptions['minApp']['groupsOnly'] = false;
  * array('//static' => 'D:\\staticStorage')  // Windows
  * </code>
  */
-$min_symlinks = array();
+$min_symlinks = (isset($_GET['symlinks']) ? $_GET['symlinks'] : array());
 
 
 /**

--- a/View/Helper/MinifyHelper.php
+++ b/View/Helper/MinifyHelper.php
@@ -36,11 +36,9 @@ class MinifyHelper extends AppHelper {
 
 		$path = '/min-' . $ext . '?f=';
 
-		foreach ($assets as $asset) {
-			$path .= ($ext . '/' . $asset . '.' . $ext . ',');
-		}
+		$path .= implode(',', $assets);
 
-		return substr($path, 0, count($path) - 2);
+		return $path;
 	}
 }
 


### PR DESCRIPTION
- Added support to serve css\js from Plugins webroot dirs
- Changed the way the filenames represent at "f="
- Fixed App::import to support CakePHP 2.2
