### PR TITLE
Fix for windows pathes.

### DIFF
--- a/Controller/MinifyController.php
+++ b/Controller/MinifyController.php
@@ -35,15 +35,15 @@ class MinifyController extends Controller {
 			$plugin = $first;
 		    }
 
-		    $pluginPath = (!empty($plugin) ? '..' . DS . 'Plugin' . DS . $plugin . DS . WEBROOT_DIR . DS : '');
-		    $file = $pluginPath . $type . DS . $file . '.' . $type;
+		    $pluginPath = (!empty($plugin) ? '../Plugin/' . $plugin . '/' . WEBROOT_DIR . '/' : '');
+		    $file = $pluginPath . $type . '/' . $file . '.' . $type;
 		    $newFiles[] = $file;
 
 		    if (!empty($plugin) && !isset($plugins[$plugin]))
 		    {
 			$plugins[$plugin] = true;
 
-			$pluginSymlinks['/' . $this->request->base . '/' . Inflector::underscore($plugin)] = APP . 'Plugin' . DS . $plugin . DS . WEBROOT_DIR;
+			$pluginSymlinks['/' . $this->request->base . '/' . Inflector::underscore($plugin)] = APP . 'Plugin/' . $plugin . '/' . WEBROOT_DIR;
 		    }
 		}
 		$_GET['f'] = implode(',', $newFiles);


### PR DESCRIPTION
Seems that Minify doesn't like Windows backslash ('\') in pathes.
Fixed to use only Linux\Web slash ('/').
Tested on Apache Debian & Apache Windows 2008.
