### PR TITLE
Fixed handling of file names starting with a '/'

### DIFF
--- a/Controller/MinifyController.php
+++ b/Controller/MinifyController.php
@@ -39,7 +39,14 @@ class MinifyController extends Controller {
 			}
 
 			$pluginPath = (! empty($plugin) ? '../Plugin/' . $plugin . '/' . WEBROOT_DIR . '/' : '');
-			$file = $pluginPath . $type . '/' . $file . '.' . $type;
+			if ($file[0] == '/') {
+				// Paths starting with a '/' should be treated
+				// relative to the application's webroot
+				$file = $file . '.' . $type;
+			} else {
+				$file = $pluginPath . $type . '/' . $file . '.' . $type;
+			}
+
 			$newFiles[] = $file;
 
 			if (! empty($plugin) && ! isset($plugins[$plugin])) {


### PR DESCRIPTION
The API documentation for `HtmlHelper::css()` says:

> If $path is prefixed with '/', the path will be relative to the webroot of your application.

This also applies to `HtmlHelper::script()`. Now if I have a directory `subdir` containing scripts and/or stylesheets in my `webroot`, I might want to do:

``` php
$this->Minify->css('/subdir/mystyle.css');
$this->Minify->script('/subdir/myscript.js');
```

But this would only work with `MinifyAsset` being disabled. Otherwise, the Minify library responds with a `400 Bad Request` response code.

In this patch, I've added some code to handle this: `$pluginPath` and `$type` are only prepended when the filename does _not_ start with a '/'.
