### PR TITLE
Fix support for CakePHP not on base URL ('/')

### DIFF
--- a/Controller/MinifyController.php
+++ b/Controller/MinifyController.php
@@ -12,11 +12,26 @@ class MinifyController extends Controller {
  * @return void
  */
 	public function index($type) {
+		if (!empty($this->request->base)) {
+			$this->_adjustFilenames();
+		}
+
 		App::import('Vendor', 'Minify.minify/index');
 
 		$this->response->statusCode('304');
 		exit();
 	}
 
+	private function _adjustFilenames() {
+		$baseUrl = $this->request->base;
+		$baseLen = strlen($baseUrl);
+		$files = explode(',', $_GET['f']);
+		foreach ($files as &$file) {
+			if (!strncmp($file, $baseUrl, $baseLen)) {
+				$file = substr($file, $baseLen);
+			}
+		}
+		$_GET['f'] = implode(',', $files);
+	}
 }
 ?>


### PR DESCRIPTION
Commit a25ed59890bedc427b929c91025496305eaef948 broke support for not-on-base-URL CakePHP deployments. For example, if my cake installation resides at `/cake`, `Helper::assetUrl` generates URLs in the form `/cake/css/...`, which are note recognized by the Minify library.

This fixes it by adjusting the file paths if `$this->request->base` is non-empty.
